### PR TITLE
Implement JWT authentication

### DIFF
--- a/DoubleLangue.Api/Controllers/AuthController.cs
+++ b/DoubleLangue.Api/Controllers/AuthController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using DoubleLangue.Domain.Dto;
+using DoubleLangue.Infrastructure.Interface.Repositories;
+using DoubleLangue.Infrastructure.Interface.Utils;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace DoubleLangue.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IConfiguration _configuration;
+
+    public AuthController(IUserRepository userRepository, IPasswordHasher passwordHasher, IConfiguration configuration)
+    {
+        _userRepository = userRepository;
+        _passwordHasher = passwordHasher;
+        _configuration = configuration;
+    }
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Login(UserLoginDto login)
+    {
+        var user = await _userRepository.GetUserByEmailAsync(login.Email);
+        if (user == null || !_passwordHasher.Verify(login.Password, user.Password))
+        {
+            return Unauthorized();
+        }
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new Claim(JwtRegisteredClaimNames.Email, user.Email),
+            new Claim(ClaimTypes.Role, user.Role.ToString())
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return Ok(new { token = new JwtSecurityTokenHandler().WriteToken(token) });
+    }
+}

--- a/DoubleLangue.Api/Controllers/UserController.cs
+++ b/DoubleLangue.Api/Controllers/UserController.cs
@@ -1,12 +1,14 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using DoubleLangue.Domain.Dto;
 using DoubleLangue.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using DoubleLangue.Domain.Models;
 using Microsoft.IdentityModel.Tokens;
 
 namespace DoubleLangue.Api.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("api/[controller]")]
 public class UserController : ControllerBase
 {

--- a/DoubleLangue.Api/DoubleLangue.Api.csproj
+++ b/DoubleLangue.Api/DoubleLangue.Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swagger.Net.UI" Version="1.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DoubleLangue.Api/Program.cs
+++ b/DoubleLangue.Api/Program.cs
@@ -7,6 +7,9 @@ using DoubleLangue.Infrastructure.Utils;
 using DoubleLangue.Services.Interfaces;
 using DoubleLangue.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,6 +23,27 @@ builder.Services.AddEntityFrameworkNpgsql().AddDbContext<AppDbContext>(option =>
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IPasswordHasher, BcryptPasswordHasher>();
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+    };
+});
+
+builder.Services.AddAuthorization();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -36,6 +60,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseAuthentication();
 
 app.UseAuthorization();
 

--- a/DoubleLangue.Api/appsettings.json
+++ b/DoubleLangue.Api/appsettings.json
@@ -8,5 +8,10 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=doublelangue_db;Username=admin;Password=admin123"
+  },
+  "Jwt": {
+    "Issuer": "DoubleLangueIssuer",
+    "Audience": "DoubleLangueAudience",
+    "Key": "SuperSecretJwtKey123!"
   }
 }

--- a/DoubleLangue.Domain/Dto/UserLoginDto.cs
+++ b/DoubleLangue.Domain/Dto/UserLoginDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DoubleLangue.Domain.Dto;
+
+public class UserLoginDto
+{
+    [Required, EmailAddress]
+    public string Email { get; set; }
+
+    [Required]
+    public string Password { get; set; }
+}


### PR DESCRIPTION
## Summary
- add JWT bearer package and configuration
- configure authentication middleware
- implement `AuthController` for login
- secure `UserController` endpoints
- add user login DTO

## Testing
- `dotnet build DoubleLangueBack.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840167952088330aa8fb00f0f689a3f