### PR TITLE
Add math problem generation service

### DIFF
--- a/DoubleLangue.Api/Program.cs
+++ b/DoubleLangue.Api/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddEntityFrameworkNpgsql().AddDbContext<AppDbContext>(option =>
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IPasswordHasher, BcryptPasswordHasher>();
+builder.Services.AddScoped<IMathProblemGeneratorService, MathProblemGeneratorService>();
 
 builder.Services.AddAuthentication(options =>
 {

--- a/DoubleLangue.Domain/Enum/MathProblemType.cs
+++ b/DoubleLangue.Domain/Enum/MathProblemType.cs
@@ -1,0 +1,8 @@
+namespace DoubleLangue.Domain.Enum;
+
+public enum MathProblemType
+{
+    Result,
+    MissingNumber,
+    MissingOperator
+}

--- a/DoubleLangue.Domain/Models/MathProblem.cs
+++ b/DoubleLangue.Domain/Models/MathProblem.cs
@@ -3,5 +3,5 @@
 public class MathProblem
 {
     public string Question { get; init; }
-    public double Answer { get; init; }
+    public string Answer { get; init; }
 }

--- a/DoubleLangue.Services/Interfaces/IMathProblemGeneratorService.cs
+++ b/DoubleLangue.Services/Interfaces/IMathProblemGeneratorService.cs
@@ -1,0 +1,9 @@
+using DoubleLangue.Domain.Enum;
+using DoubleLangue.Domain.Models;
+
+namespace DoubleLangue.Services.Interfaces;
+
+public interface IMathProblemGeneratorService
+{
+    MathProblem Generate(int level, MathProblemType type);
+}

--- a/DoubleLangue.Services/MathProblemGeneratorService.cs
+++ b/DoubleLangue.Services/MathProblemGeneratorService.cs
@@ -1,0 +1,63 @@
+using DoubleLangue.Domain.Enum;
+using DoubleLangue.Domain.Models;
+using DoubleLangue.Services.Interfaces;
+
+namespace DoubleLangue.Services;
+
+public class MathProblemGeneratorService : IMathProblemGeneratorService
+{
+    private readonly Random _random = new();
+
+    public MathProblem Generate(int level, MathProblemType type)
+    {
+        if (level < 1 || level > 3)
+        {
+            throw new ArgumentException("level must be between 1 and 3", nameof(level));
+        }
+
+        int maxValue = level switch
+        {
+            1 => 10,
+            2 => 20,
+            _ => 100
+        };
+
+        int a = _random.Next(1, maxValue + 1);
+        int b = _random.Next(1, maxValue + 1);
+        char op = "+-*/"[_random.Next(4)];
+        double result = op switch
+        {
+            '+' => a + b,
+            '-' => a - b,
+            '*' => a * b,
+            '/' => Math.Round((double)a / b, 2),
+            _ => 0
+        };
+
+        string question;
+        string answer;
+
+        switch (type)
+        {
+            case MathProblemType.MissingNumber:
+                bool hideFirst = _random.Next(2) == 0;
+                question = hideFirst ? $"__ {op} {b} = {result}" : $"{a} {op} __ = {result}";
+                answer = hideFirst ? a.ToString() : b.ToString();
+                break;
+            case MathProblemType.MissingOperator:
+                question = $"{a} __ {b} = {result}";
+                answer = op.ToString();
+                break;
+            default:
+                question = $"{a} {op} {b} = ?";
+                answer = result.ToString();
+                break;
+        }
+
+        return new MathProblem
+        {
+            Question = question,
+            Answer = answer
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `MathProblemType` enum
- update `MathProblem` model to return string answers
- create interface `IMathProblemGeneratorService`
- implement `MathProblemGeneratorService` with random generation logic
- register new service in Program.cs

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862c7d8d4148330bab6917665b9a7cc