### PR TITLE
Allow login via username or email

### DIFF
--- a/DoubleLangue.Api/Controllers/AuthController.cs
+++ b/DoubleLangue.Api/Controllers/AuthController.cs
@@ -33,7 +33,7 @@ public class AuthController : ControllerBase
     [AllowAnonymous]
     public async Task<IActionResult> Login(UserLoginDto login)
     {
-        var user = await _userRepository.GetUserByEmailAsync(login.Email);
+        var user = await _userRepository.GetUserByIdentifierAsync(login.Identifier);
         if (user == null || !_passwordHasher.Verify(login.Password, user.Password))
         {
             return Unauthorized();

--- a/DoubleLangue.Domain/Dto/User/UserLoginDto.cs
+++ b/DoubleLangue.Domain/Dto/User/UserLoginDto.cs
@@ -4,9 +4,9 @@ namespace DoubleLangue.Domain.Dto.User;
 
 public class UserLoginDto
 {
-    [Required, EmailAddress]
-    public string Email { get; set; }
+    [Required]
+    public string Identifier { get; set; } = string.Empty; // username or email
 
     [Required]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 }

--- a/DoubleLangue.Infrastructure/AppDbContext.cs
+++ b/DoubleLangue.Infrastructure/AppDbContext.cs
@@ -12,4 +12,17 @@ public class AppDbContext : DbContext
     public DbSet<Answer> Answers => Set<Answer>();
     public DbSet<Questionnaire> Questionnaires => Set<Questionnaire>();
     public DbSet<QuestionnaireQuestion> QuestionnaireQuestions => Set<QuestionnaireQuestion>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.UserName)
+            .IsUnique();
+
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.Email)
+            .IsUnique();
+    }
 }

--- a/DoubleLangue.Infrastructure/Interface/Repositories/IUserRepository.cs
+++ b/DoubleLangue.Infrastructure/Interface/Repositories/IUserRepository.cs
@@ -7,6 +7,8 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(Guid id);
     Task<List<User>> GetAllAsync();
     Task<User?> GetUserByEmailAsync(string email);
+    Task<User?> GetUserByUserNameAsync(string userName);
+    Task<User?> GetUserByIdentifierAsync(string identifier);
     Task<User> AddAsync(User user);
     Task<User?> UpdateAsync(User user);
     Task DeleteAsync(Guid id);

--- a/DoubleLangue.Infrastructure/Repositories/UserRepository.cs
+++ b/DoubleLangue.Infrastructure/Repositories/UserRepository.cs
@@ -28,6 +28,17 @@ public class UserRepository : IUserRepository
         return await _context.Users.FirstOrDefaultAsync(u => u.Email == email);
     }
 
+    public async Task<User?> GetUserByUserNameAsync(string userName)
+    {
+        return await _context.Users.FirstOrDefaultAsync(u => u.UserName == userName);
+    }
+
+    public async Task<User?> GetUserByIdentifierAsync(string identifier)
+    {
+        return await _context.Users
+            .FirstOrDefaultAsync(u => u.Email == identifier || u.UserName == identifier);
+    }
+
     public async Task<User> AddAsync(User user)
     {
         _context.Users.Add(user);

--- a/DoubleLangue.Services/UserService.cs
+++ b/DoubleLangue.Services/UserService.cs
@@ -26,6 +26,12 @@ public class UserService : IUserService
             throw new Exception("Cet email est déjà utilisé.");
         }
 
+        var existingUserName = await _userRepository.GetUserByUserNameAsync(user.UserName);
+        if (existingUserName != null)
+        {
+            throw new Exception("Ce nom d'utilisateur est déjà utilisé.");
+        }
+
         var hashedPassword = _passwordHasher.Hash(user.Password);
 
         var newUser = new User
@@ -99,6 +105,24 @@ public class UserService : IUserService
             if (existingUser is null)
             {
                 return null;
+            }
+
+            if (user.UserName != null && user.UserName != existingUser.UserName)
+            {
+                var checkName = await _userRepository.GetUserByUserNameAsync(user.UserName);
+                if (checkName != null)
+                {
+                    throw new Exception("Ce nom d'utilisateur est déjà utilisé.");
+                }
+            }
+
+            if (user.Email != null && user.Email != existingUser.Email)
+            {
+                var checkEmail = await _userRepository.GetUserByEmailAsync(user.Email);
+                if (checkEmail != null)
+                {
+                    throw new Exception("Cet email est déjà utilisé.");
+                }
             }
 
             var updatedUser = new User


### PR DESCRIPTION
## Summary
- add identifier field to login DTO
- use identifier for login in `AuthController`
- add unique indexes on `User` `UserName` and `Email`
- expose repository methods to get users by username or identifier
- validate unique username on create and update

## Testing
- `dotnet build DoubleLangueBack.sln` *(fails: command not found)*
- `dotnet test DoubleLangueBack.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645ee03aac8330817557e102be4253