### PR TITLE
Add leaderboard route and questionnaire type option

### DIFF
--- a/DoubleLangue.Api/Controllers/LeaderboardController.cs
+++ b/DoubleLangue.Api/Controllers/LeaderboardController.cs
@@ -1,0 +1,26 @@
+using DoubleLangue.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DoubleLangue.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class LeaderboardController : ControllerBase
+{
+    private readonly IUserService _userService;
+
+    public LeaderboardController(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetLeaderboard()
+    {
+        var leaderboard = await _userService.GetLeaderboardAsync();
+        return Ok(leaderboard);
+    }
+}
+

--- a/DoubleLangue.Api/Controllers/QuestionnaireController.cs
+++ b/DoubleLangue.Api/Controllers/QuestionnaireController.cs
@@ -1,4 +1,5 @@
 using DoubleLangue.Domain.Dto.Questionnaire;
+using DoubleLangue.Domain.Enum;
 using DoubleLangue.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -26,9 +27,9 @@ public class QuestionnaireController : ControllerBase
     }
 
     [HttpPost("generate")]
-    public async Task<IActionResult> GenerateQuestionnaire([FromQuery] int level = 1)
+    public async Task<IActionResult> GenerateQuestionnaire([FromQuery] int level = 1, [FromQuery] MathProblemType? type = null)
     {
-        var result = await _service.GenerateAsync(level);
+        var result = await _service.GenerateAsync(level, type);
         return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
     }
 

--- a/DoubleLangue.Domain/Dto/User/UserLeaderboardDto.cs
+++ b/DoubleLangue.Domain/Dto/User/UserLeaderboardDto.cs
@@ -1,0 +1,9 @@
+namespace DoubleLangue.Domain.Dto.User;
+
+public class UserLeaderboardDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserName { get; set; } = string.Empty;
+    public int Score { get; set; }
+}
+

--- a/DoubleLangue.Services/Interfaces/IQuestionnaireService.cs
+++ b/DoubleLangue.Services/Interfaces/IQuestionnaireService.cs
@@ -1,5 +1,6 @@
 using DoubleLangue.Domain.Dto.Questionnaire;
 using DoubleLangue.Domain.Models;
+using DoubleLangue.Domain.Enum;
 
 namespace DoubleLangue.Services.Interfaces;
 
@@ -9,5 +10,5 @@ public interface IQuestionnaireService
     Task<QuestionnaireResponseDto?> GetByIdAsync(Guid id);
     Task AddQuestionAsync(Guid questionnaireId, Guid questionId, int order);
     Task<List<QuestionnaireResponseDto>> GetAllAsync();
-    Task<QuestionnaireResponseDto> GenerateAsync(int level);
+    Task<QuestionnaireResponseDto> GenerateAsync(int level, MathProblemType? type);
 }

--- a/DoubleLangue.Services/Interfaces/IUserService.cs
+++ b/DoubleLangue.Services/Interfaces/IUserService.cs
@@ -10,4 +10,5 @@ public interface IUserService
     Task<User?> GetByIdAsync(Guid id);
     Task<UserResponseDto?> UpdateAsync(Guid id, UserUpdateDto user);
     Task DeleteAsync(Guid id);
+    Task<List<UserLeaderboardDto>> GetLeaderboardAsync();
 }

--- a/DoubleLangue.Services/QuestionnaireService.cs
+++ b/DoubleLangue.Services/QuestionnaireService.cs
@@ -41,7 +41,7 @@ public class QuestionnaireService : IQuestionnaireService
         };
     }
 
-    public async Task<QuestionnaireResponseDto> GenerateAsync(int level)
+    public async Task<QuestionnaireResponseDto> GenerateAsync(int level, MathProblemType? type)
     {
         var questionnaire = new Questionnaire
         {
@@ -53,8 +53,8 @@ public class QuestionnaireService : IQuestionnaireService
         questionnaire = await _questionnaireRepository.AddAsync(questionnaire);
         for (var i = 0; i < 10; i++)
         {
-            var rdmtype = (MathProblemType)new Random().Next(0, 3);
-            var question = await _questionService.GenerateAsync(level, rdmtype);
+            var currentType = type ?? (MathProblemType)new Random().Next(0, 3);
+            var question = await _questionService.GenerateAsync(level, currentType);
             await _questionnaireRepository.AddQuestionAsync(new QuestionnaireQuestion
             {
                 QuestionnaireId = questionnaire.Id,

--- a/DoubleLangue.Services/UserService.cs
+++ b/DoubleLangue.Services/UserService.cs
@@ -164,4 +164,18 @@ public class UserService : IUserService
             throw new Exception("Erreur lors de la suppression", ex);
         }
     }
+
+    public async Task<List<UserLeaderboardDto>> GetLeaderboardAsync()
+    {
+        var users = await _userRepository.GetAllAsync();
+        return users
+            .OrderByDescending(u => u.Score)
+            .Select(u => new UserLeaderboardDto
+            {
+                Id = u.Id.ToString(),
+                UserName = u.UserName,
+                Score = u.Score
+            })
+            .ToList();
+    }
 }


### PR DESCRIPTION
## Summary
- add leaderboard controller returning users ranked by score
- implement leaderboard retrieval in user service and interface
- add `UserLeaderboardDto` DTO
- update questionnaire generation to accept optional math problem type
- adjust questionnaire controller to pass optional type

## Testing
- `dotnet build DoubleLangueBack.sln -v q` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865430b28d8833082a95c978ae480cc