### PR TITLE
Add questionnaire evaluation and test parameter

### DIFF
--- a/DoubleLangue.Api/Controllers/QuestionnaireController.cs
+++ b/DoubleLangue.Api/Controllers/QuestionnaireController.cs
@@ -27,9 +27,9 @@ public class QuestionnaireController : ControllerBase
     }
 
     [HttpPost("generate")]
-    public async Task<IActionResult> GenerateQuestionnaire([FromQuery] int level = 1, [FromQuery] MathProblemType? type = null)
+    public async Task<IActionResult> GenerateQuestionnaire([FromQuery] int level = 1, [FromQuery] MathProblemType? type = null, [FromQuery] bool test = true)
     {
-        var result = await _service.GenerateAsync(level, type);
+        var result = await _service.GenerateAsync(level, type, test);
         return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
     }
 
@@ -49,6 +49,20 @@ public class QuestionnaireController : ControllerBase
         {
             await _service.AddQuestionAsync(id, dto.QuestionId, dto.OrderInQuiz);
             return NoContent();
+        }
+        catch (Exception e)
+        {
+            return BadRequest(e.Message);
+        }
+    }
+
+    [HttpPost("evaluate")]
+    public async Task<IActionResult> EvaluateQuestionnaire([FromBody] QuestionnaireCheckDto dto)
+    {
+        try
+        {
+            var score = await _service.CheckAnswersAsync(dto.QuestionnaireId, dto.Answers);
+            return Ok(new { score });
         }
         catch (Exception e)
         {

--- a/DoubleLangue.Domain/Dto/Questionnaire/QuestionnaireCheckDto.cs
+++ b/DoubleLangue.Domain/Dto/Questionnaire/QuestionnaireCheckDto.cs
@@ -1,0 +1,13 @@
+namespace DoubleLangue.Domain.Dto.Questionnaire;
+
+public class QuestionnaireCheckDto
+{
+    public Guid QuestionnaireId { get; set; }
+    public List<QuestionAnswerDto> Answers { get; set; } = new();
+}
+
+public class QuestionAnswerDto
+{
+    public Guid QuestionId { get; set; }
+    public string Answer { get; set; } = string.Empty;
+}

--- a/DoubleLangue.Domain/Dto/Questionnaire/QuestionnaireResponseDto.cs
+++ b/DoubleLangue.Domain/Dto/Questionnaire/QuestionnaireResponseDto.cs
@@ -14,5 +14,6 @@ public class QuestionItemDto
 {
     public Guid Id { get; set; }
     public string QuestionText { get; set; } = string.Empty;
+    public string? CorrectAnswer { get; set; }
     public int OrderInQuiz { get; set; }
 }

--- a/DoubleLangue.Services/Interfaces/IQuestionnaireService.cs
+++ b/DoubleLangue.Services/Interfaces/IQuestionnaireService.cs
@@ -10,5 +10,6 @@ public interface IQuestionnaireService
     Task<QuestionnaireResponseDto?> GetByIdAsync(Guid id);
     Task AddQuestionAsync(Guid questionnaireId, Guid questionId, int order);
     Task<List<QuestionnaireResponseDto>> GetAllAsync();
-    Task<QuestionnaireResponseDto> GenerateAsync(int level, MathProblemType? type);
+    Task<QuestionnaireResponseDto> GenerateAsync(int level, MathProblemType? type, bool isTest);
+    Task<int> CheckAnswersAsync(Guid questionnaireId, List<QuestionAnswerDto> answers);
 }


### PR DESCRIPTION
## Summary
- optionally include answers when generating questionnaires
- add DTOs to submit questionnaire answers
- implement `CheckAnswersAsync` in service
- expose new `evaluate` endpoint to score answers

## Testing
- `dotnet build DoubleLangueBack.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686559c24f188330b39de6595a5ce660